### PR TITLE
Create queues_drc.csv to resolve "No services configured" Error Message in Queues

### DIFF
--- a/configuration/backend_configuration/queues/queues_drc.csv
+++ b/configuration/backend_configuration/queues/queues_drc.csv
@@ -1,0 +1,3 @@
+UUID,Name,Service,Location,Status Concept Set,Priority Concept Set
+d692a223-e140-11ee-bad2-0242ac120002,Outpatient Triage,d62d58e9-ec91-4108-9643-00f5f23bf51c,44c3efb0-2583-4c80-a79e-1f756a03c0a1,,
+13b656d3-e141-11ee-bad2-0242ac120002,Outpatient Consultation,e96e2ce6-e326-46f2-8015-17572689c401,44c3efb0-2583-4c80-a79e-1f756a03c0a1,,


### PR DESCRIPTION
Copying the queues.csv setup that we have in the OpenMRS EMR (RefApp), to unblock the error message faced in the DRC Service Queues UI when you try to add a patient to a queue.

Should fix this: 
<img width="1833" alt="image" src="https://github.com/user-attachments/assets/b926e706-1af8-420a-8696-1738f1f51396" />
