### PR TITLE
Update queues_drc.csv to make locations blank

### DIFF
--- a/configuration/backend_configuration/queues/queues_drc.csv
+++ b/configuration/backend_configuration/queues/queues_drc.csv
@@ -1,3 +1,3 @@
 UUID,Name,Service,Location,Status Concept Set,Priority Concept Set
-d692a223-e140-11ee-bad2-0242ac120002,Outpatient Triage,d62d58e9-ec91-4108-9643-00f5f23bf51c,7de9a0a7-b73c-4fba-9037-50e0d387984b,,
-13b656d3-e141-11ee-bad2-0242ac120002,Outpatient Consultation,e96e2ce6-e326-46f2-8015-17572689c401,7de9a0a7-b73c-4fba-9037-50e0d387984b,,
+d692a223-e140-11ee-bad2-0242ac120002,Outpatient Triage,d62d58e9-ec91-4108-9643-00f5f23bf51c,,,
+13b656d3-e141-11ee-bad2-0242ac120002,Outpatient Consultation,e96e2ce6-e326-46f2-8015-17572689c401,,,


### PR DESCRIPTION
Hoping this will make all locations benefit from the same demo queue service options.