### PR TITLE
Update hiv_death_form_translations_fr.json

### DIFF
--- a/Base Content Package/configuration/backend_configuration/ampathformstranslations/hiv_death_form_translations_fr.json
+++ b/Base Content Package/configuration/backend_configuration/ampathformstranslations/hiv_death_form_translations_fr.json
@@ -1,7 +1,7 @@
 {
   "uuid": "",
   "form": "Death Form",
-  "form_name_translation": "Formulaire de décès lié au VIH",
+  "form_name_translation": "Formulaire sur la cause du décès lié au VIH",
   "description": "Traductions en français pour le formulaire de décès dû au VIH",
   "language": "fr",
   "translations": {


### PR DESCRIPTION
Renamed Death Form to → Formulaire sur la cause du décès lié au VIH